### PR TITLE
Fix #32 installation of yq in image-check actions

### DIFF
--- a/.github/workflows/base-csgo-image-check.yml
+++ b/.github/workflows/base-csgo-image-check.yml
@@ -63,8 +63,8 @@ jobs:
         if: ${{ steps.checkpr_csgo.outputs.result == 'continue' }}
         run: |
           # Install yq
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends yq
+          sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
           # Prepare git user
           git config user.name github-actions

--- a/.github/workflows/base-legacy-image-check.yml
+++ b/.github/workflows/base-legacy-image-check.yml
@@ -63,8 +63,8 @@ jobs:
         if: ${{ steps.checkpr_legacy.outputs.result == 'continue' }}
         run: |
           # Install yq
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends yq
+          sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
           # Prepare git user
           git config user.name github-actions


### PR DESCRIPTION
This PR should fix #32. Im not able to test the Github action since i am not able to trigger it in my fork manually for whatever reason.

It changes the installation of the yq.
https://github.com/mikefarah/yq#latest-version