### PR TITLE
Fix #32 again, since yq arguments have changed

### DIFF
--- a/.github/workflows/base-csgo-image-check.yml
+++ b/.github/workflows/base-csgo-image-check.yml
@@ -76,10 +76,8 @@ jobs:
           git checkout -b actions/bump-base-csgo-image-tag
 
           # Replace base-csgo image tag
-          cat docker-compose.yml | yq -M -y '.services."base-csgo".build.args.STEAMRT_PLATFORM_VERSION = "${CI_PR_NEW_BASE_CSGO_IMAGE_TAG}"' > docker-compose-new.yml
-          rm -rf docker-compose.yml
-          mv docker-compose-new.yml docker-compose.yml
-
+          yq -i '.services."base-csgo".build.args.STEAMRT_PLATFORM_VERSION = "${CI_PR_NEW_BASE_CSGO_IMAGE_TAG}"' docker-compose.yml
+          
           # Add, commit and push changes to the branch
           git add docker-compose.yml
           git commit -m "Bump base-csgo image tag to ${CI_PR_NEW_BASE_CSGO_IMAGE_TAG}"

--- a/.github/workflows/base-legacy-image-check.yml
+++ b/.github/workflows/base-legacy-image-check.yml
@@ -76,9 +76,7 @@ jobs:
           git checkout -b actions/bump-base-legacy-image-tag
 
           # Replace base-legacy image tag
-          cat docker-compose.yml | yq -M -y '.services."base-legacy".build.args.STEAMRT_PLATFORM_VERSION = "${CI_PR_NEW_BASE_LEGACY_IMAGE_TAG}"' > docker-compose-new.yml
-          rm -rf docker-compose.yml
-          mv docker-compose-new.yml docker-compose.yml
+          yq -i '.services."base-legacy".build.args.STEAMRT_PLATFORM_VERSION = "${CI_PR_NEW_BASE_LEGACY_IMAGE_TAG}"' docker-compose.yml
 
           # Add, commit and push changes to the branch
           git add docker-compose.yml


### PR DESCRIPTION
Seems like the updated yq version has different arguments. Hence we got following error.

> ```
> Error: unknown shorthand flag: 'y' in -y
> Usage:
>   yq [flags]
>   yq [command]
> 
> Examples:
> 
> # yq defaults to 'eval' command if no command is specified. See "yq eval --help" for more examples.
> 
> # read the "stuff" node from "myfile.yml"
> yq '.stuff' < myfile.yml
> 
> # update myfile.yml in place
> yq -i '.stuff = "foo"' myfile.yml
> 
> # print contents of sample.json as idiomatic YAML
> yq -P sample.json
> 
> ```

Im using the `-i` option from yq to update the image-tag inside the docker-compose.yml in place.